### PR TITLE
Bugfix: prefixed audio/document_card ID with 'uuid_' to make document querySelector() happy.

### DIFF
--- a/src/galleries/templates/includes/audio_card.html
+++ b/src/galleries/templates/includes/audio_card.html
@@ -1,6 +1,6 @@
 {% load static %}
 <div style="display: none">
-  <div id="{{ file.uuid }}" style="width: 100%; height: 100%">
+  <div id="uuid_{{ file.uuid }}" style="width: 100%; height: 100%">
     <figure>
       <figcaption>{{ file.title }}</figcaption>
       <audio controls src="{{ file.original.url }}">
@@ -11,7 +11,7 @@
 </div>
 
 <div class="card shadow-sm">
-  <p class="text-center mt-1"><a class="spotlight" data-media="node" data-src="#{{ file.uuid }}"><i class="fas fa-file-audio fa-10x card-img-top"></i></a></p>
+  <p class="text-center mt-1"><a class="spotlight" data-media="node" data-src="#uuid_{{ file.uuid }}"><i class="fas fa-file-audio fa-10x card-img-top"></i></a></p>
   <div class="card-body">
     <h5 class="card-title"><i class="fas fa-file-audio fs-5"></i> {{ file.title }}</h5>
     <small class="text-muted">Tags</small>

--- a/src/galleries/templates/includes/document_card.html
+++ b/src/galleries/templates/includes/document_card.html
@@ -1,12 +1,12 @@
 {% load static %}
 <div style="display: none">
-  <div id="{{ file.uuid }}" style="width: 100%; height: 100%">
+  <div id="uuid_{{ file.uuid }}" style="width: 100%; height: 100%">
     <embed src="{{ file.original.url }}" type="application/pdf" width="100%" height="100%">
   </div>
 </div>
 
 <div class="card shadow-sm">
-  <p class="text-center mt-1"><a class="spotlight" data-media="node" data-src="#{{ file.uuid }}"><i class="fas fa-file-pdf fa-10x card-img-top"></i></a></p>
+  <p class="text-center mt-1"><a class="spotlight" data-media="node" data-src="#uuid_{{ file.uuid }}"><i class="fas fa-file-pdf fa-10x card-img-top"></i></a></p>
   <div class="card-body">
     <h5 class="card-title"><i class="fas fa-file-pdf fs-5"></i> {{ file.title }}</h5>
     <small class="text-muted">Tags</small>


### PR DESCRIPTION
A valid name should start with an underscore (_), a hyphen (-) or a letter (a-z)/(A-Z) which is followed by any numbers, hyphens, underscores, letters.
It cannot start with a digit, starting with the digit is acceptable by HTML5 but not acceptable by CSS.
Two hyphens followed by a number is valid.

[ref](https://www.geeksforgeeks.org/which-characters-are-valid-in-css-class-names-selectors/)