### PR TITLE
Updated 'boostrap5' tag into 'django_bootstrap5'

### DIFF
--- a/src/audios/templates/audios_manage_list.html
+++ b/src/audios/templates/audios_manage_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}Manage Audios{% endblock title %}
 
 {% block content %}

--- a/src/documents/templates/documents_manage_list.html
+++ b/src/documents/templates/documents_manage_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}Manage Documents{% endblock title %}
 
 {% block content %}

--- a/src/files/templates/files_approval_confirm.html
+++ b/src/files/templates/files_approval_confirm.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}{{ approval_type|capfirst}} file{% endblock title %}
 
 {% block content %}

--- a/src/files/templates/files_manage_delete.html
+++ b/src/files/templates/files_manage_delete.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}Delete file{% endblock title %}
 
 {% block content %}

--- a/src/files/templates/files_manage_detail.html
+++ b/src/files/templates/files_manage_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}File details{% endblock title %}
 
 {% block content %}

--- a/src/files/templates/files_manage_edit.html
+++ b/src/files/templates/files_manage_edit.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}Edit file details{% endblock title %}
 
 {% block content %}

--- a/src/files/templates/files_manage_list.html
+++ b/src/files/templates/files_manage_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% load guardian_tags %}
 {% block title %}Manage Files{% endblock title %}
 

--- a/src/pictures/templates/pictures_manage_list.html
+++ b/src/pictures/templates/pictures_manage_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}Manage Pictures{% endblock title %}
 
 {% block content %}

--- a/src/videos/templates/videos_manage_list.html
+++ b/src/videos/templates/videos_manage_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load bootstrap5 %}
+{% load django_bootstrap5 %}
 {% block title %}Manage Videos{% endblock title %}
 
 {% block content %}


### PR DESCRIPTION
Not sure if this changed since last, but I got an invalid tag from Django debug when accessing sites using `boostrap5` instead of `django_bootstrap5`