### PR TITLE
Added 'DEBUG_TOOLBAR' to env.dist 

### DIFF
--- a/src/bma/.env.dist
+++ b/src/bma/.env.dist
@@ -1,5 +1,6 @@
 #DJANGO_SECRET_KEY=a-long-randomsecret-key
-#DJANGO_DEBUG=on
+#DJANGO_DEBUG=True
+#DEBUG_TOOLBAR=True
 #DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 #DJANGO_DATABASE_URL=postgres://bma:hunter12@127.0.0.1:5432/bmadb
 #DJANGO_ADMIN_PREFIX=notadmin


### PR DESCRIPTION
for making sure a new configured project doesnt fail with missing namespace for 'djdt'.