### PR TITLE
License explainer inside the upload card

### DIFF
--- a/src/files/templates/upload.html
+++ b/src/files/templates/upload.html
@@ -11,7 +11,7 @@
         </div>
         <div class="card-body license-card">
             <p class="fs-3">Creative Commons licenses</p>
-          <div class="row row-cols-1 row-cols-sm-3 g-3 justify-content-center my-3">
+          <div class="row g-3 justify-content-center my-3">
             <div class="col-lg-4 d-flex align-items-stretch">
               <div class="card">
                 <div class="card-body text-center p-4">

--- a/src/files/templates/upload.html
+++ b/src/files/templates/upload.html
@@ -3,7 +3,7 @@
 {% block title %}Upload Files{% endblock title %}
 
 {% block content %}
-  <div class="row d-flex justify-content-center align-items-center">
+  <div class="row d-flex justify-content-end align-items-start">
     <div class="col-lg-6 col-sm-8">
       <div class="card">
         <div class="card-header">
@@ -41,6 +41,41 @@
         </div>
         <div class="card-footer">
             <button id="btnupload" onclick="uploadFiles()" class="btn btn-success" disabled>Upload files</button>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-3 col-sm-8">
+      <div class="card">
+        <div class="card-header">
+          <h5 class="card-title">License explainer</h5>
+        </div>
+        <div class="card-body">
+          <div class="row">
+            <div class="col mt-3">
+              <ul>
+                <li>CC0 1.0 Universal</li>
+                <ul>
+                  <li>By marking the work with a CC0 public domain
+                 dedication, the creator is giving up their copyright and allowing reusers to
+                 distribute, remix, adapt, and build upon the material in any medium or format, even
+                 for commercial purposes.</li>
+                </ul>
+                <li>Creative Commons Attribution 4.0 International</li>
+                <ul>
+                  <li>Requires that reusers give credit to the creator. It allows reusers to distribute,
+                 remix, adapt, and build upon the material in any medium or format, even for commercial
+                 purposes.</li>
+                </ul>
+                <li>Creative Commons Attribution-ShareAlike 4.0 International</li>
+                <ul>
+                  <li>Requires that reusers give credit to the creator. It allows reusers to
+                 distribute, remix, adapt, and build upon the material in any medium or format, even
+                 for commercial purposes. If others remix, adapt, or build upon the material, they must
+                 license the modified material under identical terms.</li>
+                </ul>
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/files/templates/upload.html
+++ b/src/files/templates/upload.html
@@ -52,7 +52,7 @@
         <div class="card-body">
           <div class="row">
             <div class="col mt-3">
-              <ul>
+              <ul class="text-secondary">
                 <li>CC0 1.0 Universal</li>
                 <ul>
                   <li>By marking the work with a CC0 public domain

--- a/src/files/templates/upload.html
+++ b/src/files/templates/upload.html
@@ -3,13 +3,62 @@
 {% block title %}Upload Files{% endblock title %}
 
 {% block content %}
-  <div class="row d-flex justify-content-end align-items-start">
+  <div class="row justify-content-center">
     <div class="col-lg-6 col-sm-8">
       <div class="card">
         <div class="card-header">
           <h5 class="card-title">Upload</h5>
         </div>
-        <div class="card-body">
+        <div class="card-body license-card">
+            <p class="fs-3">Creative Commons licenses</p>
+          <div class="row row-cols-1 row-cols-sm-3 g-3 justify-content-center my-3">
+            <div class="col-lg-4 d-flex align-items-stretch">
+              <div class="card">
+                <div class="card-body text-center p-4">
+                  <i class="fa-brands fa-creative-commons-zero fa-5x mb-3"></i>
+                  <h5 class="card-title mb-3">CC0 1.0 Universal</h5>
+                  <p class="card-text mb-4 text-secondary">
+                  The creator is giving up their copyright and allowing reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.
+                  </p>
+                </div>
+                <div class="card-footer">
+                  <a href="https://creativecommons.org/publicdomain/zero/1.0/" class="fw-bold text-decoration-none link-primary" target="_blank">Learn more</a>
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-4 d-flex align-items-stretch">
+              <div class="card">
+                <div class="card-body text-center p-4">
+                  <i class="fa-brands fa-creative-commons-by fa-5x mb-3"></i>
+                  <h5 class="card-title mb-3">Attribution 4.0 International</h5>
+                  <p class="card-text mb-4 text-secondary">
+                  Requires that reusers give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.
+                  </p>
+                </div>
+                <div class="card-footer">
+                  <a href="https://creativecommons.org/licenses/by/4.0/" class="fw-bold text-decoration-none link-primary" target="_blank">Learn more</a>
+                </div>
+              </div>
+            </div>
+            <div class="col-lg-4 d-flex align-items-stretch">
+              <div class="card">
+                <div class="card-body text-center p-4">
+                  <i class="fa-brands fa-creative-commons-sa fa-5x mb-3"></i>
+                  <h5 class="card-title mb-3">Attribution-ShareAlike 4.0 International</h5>
+                  <p class="card-text text-secondary mb-1">
+                  Attribution 4.0 International
+                  </p>
+                  <i class="fa-solid fa-plus fa-2x py-2 text-secondary"></i>
+                  <p class="card-text text-secondary">
+                  If others remix, adapt, or build upon the material, they must license the modified material under identical terms.
+                  </p>
+                </div>
+                <div class="card-footer">
+                  <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="fw-bold text-decoration-none link-primary" target="_blank">Learn more</a>
+                </div>
+              </div>
+            </div>
+          </div>
           <div class="row">
             <div class="col mt-3">
                 <p class="fs-3">Metadata</p>
@@ -41,41 +90,6 @@
         </div>
         <div class="card-footer">
             <button id="btnupload" onclick="uploadFiles()" class="btn btn-success" disabled>Upload files</button>
-        </div>
-      </div>
-    </div>
-    <div class="col-lg-3 col-sm-8">
-      <div class="card">
-        <div class="card-header">
-          <h5 class="card-title">License explainer</h5>
-        </div>
-        <div class="card-body">
-          <div class="row">
-            <div class="col mt-3">
-              <ul class="text-secondary">
-                <li>CC0 1.0 Universal</li>
-                <ul>
-                  <li>By marking the work with a CC0 public domain
-                 dedication, the creator is giving up their copyright and allowing reusers to
-                 distribute, remix, adapt, and build upon the material in any medium or format, even
-                 for commercial purposes.</li>
-                </ul>
-                <li>Creative Commons Attribution 4.0 International</li>
-                <ul>
-                  <li>Requires that reusers give credit to the creator. It allows reusers to distribute,
-                 remix, adapt, and build upon the material in any medium or format, even for commercial
-                 purposes.</li>
-                </ul>
-                <li>Creative Commons Attribution-ShareAlike 4.0 International</li>
-                <ul>
-                  <li>Requires that reusers give credit to the creator. It allows reusers to
-                 distribute, remix, adapt, and build upon the material in any medium or format, even
-                 for commercial purposes. If others remix, adapt, or build upon the material, they must
-                 license the modified material under identical terms.</li>
-                </ul>
-              </ul>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/static_src/css/bma.css
+++ b/src/static_src/css/bma.css
@@ -9,3 +9,7 @@ main > .container {
     object-fit: cover;
     text-align: center;
 }
+
+.license-card .card-title {
+  min-height: 2.5em;
+}


### PR DESCRIPTION
Instead of doing tooltips I added a responsive card for each license type.

If we create a license entity containing:
- Title
- Link
- Description
- FontAwesome icon reference

the cards can be rendered dynamically in case we add more licenses. For now they are static

XL
![image](https://github.com/bornhack/bma/assets/17219001/e0547b20-bfb0-4fa0-b6c7-0483fe7eea3b)

MD
![image](https://github.com/bornhack/bma/assets/17219001/fd2deb82-403a-4545-947c-7abd1a3cfacf)

SM
![image](https://github.com/bornhack/bma/assets/17219001/d7380075-8c1e-4e7c-8054-f92967e72a4f)
