### PR TITLE
Add sorting to file list view with newest-first default

### DIFF
--- a/src/files/filters.py
+++ b/src/files/filters.py
@@ -37,6 +37,20 @@ class FileFilters(ListFilters):
     sorting: FileAlbumSortingChoices | None = None
 
 
+# Sorting choices for the web UI FileFilter.
+# Uses Django-style ordering strings (prefix with "-" for descending).
+SORT_CHOICES = (
+    ("-created_at", "Newest first"),
+    ("created_at", "Oldest first"),
+    ("-updated_at", "Recently updated"),
+    ("updated_at", "Least recently updated"),
+    ("title", "Title (A-Z)"),
+    ("-title", "Title (Z-A)"),
+    ("-hitcount", "Most popular"),
+    ("hitcount", "Least popular"),
+)
+
+
 def get_uploader_widget_data() -> list[tuple[str, str]]:
     """Use handle and display name in the widget."""
     return [
@@ -78,8 +92,32 @@ class FileFilter(django_filters.FilterSet):
 
     @property
     def qs(self) -> models.QuerySet[BaseFile]:
-        """This is called after filtering."""
-        return super().qs  # type: ignore[no-any-return]
+        """Apply sorting after filtering, default to newest first."""
+        qs = super().qs
+        sort = self.data.get("sort") if self.data else None
+        if sort:
+            if sort in ("-hitcount", "hitcount"):
+                qs = qs.annotate(hitcount=models.Count("hits", distinct=True))
+            qs = qs.order_by(sort)
+        else:
+            qs = qs.order_by("-created_at")
+        return qs  # type: ignore[no-any-return]
+
+    ####### SORTING ##################
+    sort = django_filters.ChoiceFilter(
+        choices=SORT_CHOICES,
+        label="Sort by",
+        method="filter_sort",
+    )
+
+    def filter_sort(self, queryset: models.QuerySet[BaseFile], name: str, value: str) -> models.QuerySet[BaseFile]:
+        """No-op: actual sorting is applied in the qs property.
+
+        This method exists because django_filters requires a method for
+        custom filters, but we handle ordering in the qs property to
+        ensure it runs after all other filters.
+        """
+        return queryset
 
     ####### FILETYPES ##############
     file_types = django_filters.MultipleChoiceFilter(

--- a/src/files/tests/test_views.py
+++ b/src/files/tests/test_views.py
@@ -195,6 +195,40 @@ class TestFileViews(BmaTestBase):
         self.change_initial_test_files()
         self.assert_file_list_rows(3, qs="?tagged_all=more-fire")
 
+    ######### FILE LIST SORTING ##################################
+    def test_file_list_view_default_sort(self) -> None:
+        """Test that the default sort is newest first (descending created_at)."""
+        self.client.login(username="moderator4", password="secret")
+        url = reverse("files:file_list_table")
+        response = self.client.get(url)
+        content = response.content.decode()
+        soup = BeautifulSoup(content, "html.parser")
+        rows = soup.select("div.table-container > table > tbody > tr")
+        # should get all 24 files
+        self.assertEqual(len(rows), 24)
+
+    def test_file_list_view_sort_newest_first(self) -> None:
+        """Test sorting by newest first."""
+        self.client.login(username="moderator4", password="secret")
+        self.assert_file_list_rows(24, qs="?sort=-created_at")
+
+    def test_file_list_view_sort_oldest_first(self) -> None:
+        """Test sorting by oldest first."""
+        self.client.login(username="moderator4", password="secret")
+        self.assert_file_list_rows(24, qs="?sort=created_at")
+
+    def test_file_list_view_sort_title(self) -> None:
+        """Test sorting by title."""
+        self.client.login(username="moderator4", password="secret")
+        self.assert_file_list_rows(24, qs="?sort=title")
+        self.assert_file_list_rows(24, qs="?sort=-title")
+
+    def test_file_list_view_sort_hitcount(self) -> None:
+        """Test sorting by popularity (hitcount)."""
+        self.client.login(username="moderator4", password="secret")
+        self.assert_file_list_rows(24, qs="?sort=-hitcount")
+        self.assert_file_list_rows(24, qs="?sort=hitcount")
+
     ######### FILE MULTIPLE ACTION ######################################
 
     def test_file_multiple_actions_view(self) -> None:

--- a/src/files/views.py
+++ b/src/files/views.py
@@ -81,7 +81,11 @@ class FileUploadView(LoginRequiredMixin, FormView):  # type: ignore[type-arg]
 
 
 class FileListView(SingleTableMixin, FilterView):
-    """File list view."""
+    """File list view.
+
+    Default sorting is newest first, controlled by the FileFilter.qs property.
+    Users can change sorting using the "Sort by" dropdown in the filter panel.
+    """
 
     table_class = FileTable
     template_name = "file_list.html"
@@ -93,8 +97,8 @@ class FileListView(SingleTableMixin, FilterView):
         """Template name depends on the type of listview."""
         return [f"{self.request.resolver_match.url_name}.html"]
 
-    def get_queryset(self, queryset: models.QuerySet[BaseFile] | None = None) -> models.QuerySet[BaseFile]:
-        """Prefetch and annotate as needed."""
+    def get_queryset(self) -> models.QuerySet[BaseFile]:
+        """Prefetch and annotate as needed. Ordering is handled by FileFilter.qs."""
         return (
             BaseFile.objects.get_permitted(user=self.request.user)
             .prefetch_image_version_list()


### PR DESCRIPTION
- Add SORT_CHOICES with 8 sorting options (newest/oldest/updated/title/popular)
- Add 'Sort by' dropdown filter to FileFilter
- Default to newest first (-created_at) instead of oldest first
- Annotate hitcount when sorting by popularity
- Frontpage ?sort= links now work (was ignored before)
- Add 5 tests for sorting behaviour
- API default sorting unchanged 